### PR TITLE
Remove unused enum

### DIFF
--- a/src/core.rs
+++ b/src/core.rs
@@ -29,16 +29,6 @@ impl ServerCertVerifier for NoVerifier {
 }
 // --- END: NoVerifier ---
 
-#[allow(dead_code)]
-/// Custom error types for certificate checking operations
-pub enum CertError {
-    /// Failed to parse URL
-    UrlParseError(String),
-    /// Failed to connect
-    ConnectionError(String),
-    /// Failed to parse certificate
-    ParseError(String),
-}
 
 /// Check a single certificate
 pub async fn check_certificate(url: &str, warning_days: u32, concurrent: usize) -> Result<CertificateChain, CertCheckerError> {


### PR DESCRIPTION
## Summary
- delete unused `CertError` enum
- remove its `dead_code` attribute

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_6846915b41f0832b900d2640fa2b6f27